### PR TITLE
fix: simple promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,16 +25,13 @@ const fetchBook = async url => {
   return Promise.resolve(response);
 };
 
-const fetchVolumes = async serie => {
-  const response = await rp({
+const fetchVolumes = serie =>
+  rp({
     uri: serie.url,
     transform(body) {
       return cheerio.load(body);
     },
   });
-
-  return Promise.resolve(response);
-};
 
 // Get the root page
 const fetchAll = () => {


### PR DESCRIPTION
`Promise.resolve()` is usefull to return a Promise with a value that is not a promise (like boolean, object, ...). `Promise.resolve(somePromise)` is totally useless.

Function declaration with `async` force the result of the function to be a promise (even if you return anything else like bool, number, ...). But `rp(...)` already return a promise. So you dont need to make your function async.